### PR TITLE
Typos and Minor Corrections for Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $(function(){
 	});
 });
 ```
-Each Nessie client method each returns an object which provides access to data for your desired use.
+Each Nessie client method returns an object which provides access to data for your desired use.
 ```javascript
 function accountDemo (apikey, account) {
 	console.log('Account Demo');

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nessie-JavaScript-SDK
 ##Synopsis
-Capital One Nessie API SDK written in JavasScript and wrapped in require-jquery. This SDK can be easily embeddded in web apps.
+Capital One Nessie API SDK written in JavaScript and wrapped in require-jquery. This SDK can be easily embedded in web apps.
 ##Installation for Web App
 1. Download the lib directory.
 2. Save the library in the web project directory.
@@ -20,7 +20,7 @@ $(function(){
 		});
 });
 ```
-The nessie client methods return an object which provides access to data for your desired use.
+The Nessie client methods return an object which provides access to data for your desired use.
 ```javascript
 function accountDemo (apikey, account) {
 	console.log('Account Demo');

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $(function(){
 	});
 });
 ```
-The Nessie client methods each returns an object which provides access to data for your desired use.
+Each Nessie client method each returns an object which provides access to data for your desired use.
 ```javascript
 function accountDemo (apikey, account) {
 	console.log('Account Demo');

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Capital One Nessie API SDK written in JavaScript and wrapped in require-jquery. 
 ##Installation for Web App
 1. Download the lib directory.
 2. Save the library in the web project directory.
-3. Include the library in the header of the project as shown below:
-```
+3. Include the library in the header of the project (double check your directory path!) as shown below:
+```javascript
 <script data-main="lib/capital_one" src="lib/require-jquery.js"></script>
-
 ```
 ##Usage
 1. Require the Nessie library you intend to use, within the function to execute after the DOM is ready.
@@ -17,15 +16,15 @@ $(function(){
 	require(['account'], function (account) {
 		var apikey = 'YOUR-API-KEY';
 		accountDemo(apikey, account);
-		});
+	});
 });
 ```
-The Nessie client methods return an object which provides access to data for your desired use.
+The Nessie client methods each returns an object which provides access to data for your desired use.
 ```javascript
 function accountDemo (apikey, account) {
 	console.log('Account Demo');
 	var custAccount = account.initWithKey(apikey);
-	console.log("[Account - Get All] : Sample Account Nickname: (" + custAccount.getAll()[0].nickname + ")");
+	console.log("[Account - Get All] : Sample Account Nickname: (" + custAccount.getAllAccounts()[0].nickname + ")");
 }
 ```
 You can find examples [here](https://github.com/nessieisreal/nessie-javascript-sdk/blob/master/lib/example.html).

--- a/lib/unit_tests.html
+++ b/lib/unit_tests.html
@@ -11,8 +11,8 @@
     <title>Nessie Javascript SDK Tests</title>
     
     <!-- QUnit Required Files -->
-    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.20.0.css">
-    <script src="http://code.jquery.com/qunit/qunit-1.20.0.js"></script>
+    <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.20.0.css">
+    <script src="//code.jquery.com/qunit/qunit-1.20.0.js"></script>
 
     <!-- Nessie Required Files -->
     <script data-main="capital_one" src="require-jquery.js"></script>

--- a/lib/unit_tests.html
+++ b/lib/unit_tests.html
@@ -11,8 +11,8 @@
     <title>Nessie Javascript SDK Tests</title>
     
     <!-- QUnit Required Files -->
-    <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.20.0.css">
-    <script src="//code.jquery.com/qunit/qunit-1.20.0.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.20.0.css">
+    <script src="http://code.jquery.com/qunit/qunit-1.20.0.js"></script>
 
     <!-- Nessie Required Files -->
     <script data-main="capital_one" src="require-jquery.js"></script>


### PR DESCRIPTION
# Release Notes
- Fixed typos in README
  - Sample code updated to use `getAllAccounts()` instead of `getAll()` which has been deprecated
